### PR TITLE
Copy in binary based on environment variable URL in shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ image-base: prepare-dirs ### Build a TDX general purpose base image, by default 
 		--build-arg MANIFEST=tdx-base.xml \
 		--build-arg REVISION=$(REVISION) \
 		--build-arg ENTROPY_TSS_BINARY_URI=$(ENTROPY_TSS_BINARY_URI) \
+		--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		$(REPRODUCIBLE_BUILD_DIR)
 	$(DOCKER) run --rm --env-file yocto-build-config.env \
 		-v $(REPRODUCIBLE_BUILD_DIR)/artifacts-base:/artifacts \

--- a/reproducible-build/Dockerfile
+++ b/reproducible-build/Dockerfile
@@ -15,4 +15,9 @@ ENV REVISION=${REVISION}
 ARG ENTROPY_TSS_BINARY_URI
 ENV ENTROPY_TSS_BINARY_URI=${ENTROPY_TSS_BINARY_URI}
 
+# This is used for downloading the binary from the entropy-core release pipeline
+# It is not needed if the binary source can be downloaded without an authorization token
+ARG GITHUB_TOKEN
+ENV GITHUB_TOKEN=${GITHUB_TOKEN}
+
 CMD /usr/bin/build

--- a/reproducible-build/Dockerfile
+++ b/reproducible-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/crops/poky@sha256:f51ae3279f98768514273061336421e686e13d0a42fdb056c0b88c9afeec8c56 as builder
+FROM docker.io/crops/poky@sha256:f51ae3279f98768514273061336421e686e13d0a42fdb056c0b88c9afeec8c56 AS builder
 
 USER root
 RUN apt install -y repo

--- a/reproducible-build/build.sh
+++ b/reproducible-build/build.sh
@@ -14,6 +14,8 @@ cd /build
 repo init -u https://github.com/entropyxyz/yocto-build.git -b ${REVISION} -m tdx-base.xml
 repo sync
 
+source setup || true
+
 # Download entropy-tss BINARY_FILENAME
 if echo $ENTROPY_TSS_BINARY_URI | grep -q 'github.com'; then
     # If its coming from github include our github token
@@ -45,8 +47,6 @@ chmod a+x entropy-tss
 
 # Move file to binary location directory
 mv entropy-tss srcs/poky/meta-entropy-tss/recipes-core/entropy-tss/.
-
-source setup || true
 
 make build || true
 

--- a/reproducible-build/build.sh
+++ b/reproducible-build/build.sh
@@ -10,8 +10,25 @@ git config --global color.ui true
 
 cd /build
 
+# Clone git repos
 repo init -u https://github.com/entropyxyz/yocto-build.git -b ${REVISION} -m tdx-base.xml
 repo sync
+
+# Download entropy-tss binary
+# TODO --header='Authorization: token $GITHUB_TOKEN'
+wget -O entropy-tss $ENTROPY_TSS_BINARY_URI
+
+# TODO unzip and get amd64 version
+
+# TODO sha256sum entropy-tss
+# then append `SRC_URI[sha256sum] = "$SHA256SUM"` to srcs/poky/meta-entropy-tss/recipes-core/entropy-tss/entropy-tss.bb
+#
+# Set executable permissions
+chmod a+x entropy-tss
+
+# Move file to binary location directory
+mv entropy-tss srcs/poky/meta-entropy-tss/recipes-core/entropy-tss/.
+
 
 source setup || true
 

--- a/tdx-base.xml
+++ b/tdx-base.xml
@@ -14,5 +14,5 @@
   <project remote="flashbots"       revision="scarthgap"        name="meta-openembedded"               path="srcs/poky/meta-openembedded"/>
   <project remote="flashbots"       revision="v3"               name="meta-confidential-compute"       path="srcs/poky/meta-confidential-compute"/>
 
-  <project remote="entropyxyz"       revision="main"               name="meta-entropy-tss"       path="srcs/poky/meta-entropy-tss"/>
+  <project remote="entropyxyz"       revision="peg/rm-hardcoded-binary"               name="meta-entropy-tss"       path="srcs/poky/meta-entropy-tss"/>
 </manifest>


### PR DESCRIPTION
This allows the URL to the entropy-tss binary to be passed in as an environment variable as before, but it downloads and processes the file in a build script in this repo rather than in the bitbake recipe in meta-entropy-tss. That is, meta-entropy-tss assumes the binary has already been copied in by the script here. 